### PR TITLE
Changes to support Spring Boot 1.5.1

### DIFF
--- a/authcode/build.gradle
+++ b/authcode/build.gradle
@@ -3,14 +3,14 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.5.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.1.RELEASE")
     }
 }
 
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
-apply plugin: 'spring-boot'
+apply plugin: 'org.springframework.boot'
 
 repositories {
     maven { url "https://repo.spring.io/libs-release-local" }
@@ -20,6 +20,13 @@ repositories {
 dependencies {
     compile 'org.springframework.boot:spring-boot-starter-thymeleaf'
     compile 'org.springframework.cloud:spring-cloud-starter-oauth2'
-    compile 'org.springframework.cloud:spring-cloud-cloudfoundry-connector:1.2.0.RELEASE'
+    compile 'org.springframework.cloud:spring-cloud-cloudfoundry-connector'
     compile 'io.pivotal.spring.cloud:spring-cloud-sso-connector:1.1.0.RELEASE'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "io.pivotal.spring.cloud:spring-cloud-services-dependencies:1.3.1.RELEASE"
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:Camden.SR3"
+    }
 }

--- a/authcode/src/main/resources/application.yml
+++ b/authcode/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
   thymeleaf:
     cache: false
 security:
-  ignored: /favicon.ico, /, /authorization_code
+  ignored: /favicon.ico, /
   basic:
     enabled: false
 logging.level:


### PR DESCRIPTION
This PR contains changes to support Spring Boot 1.5.1 - the `OAuth2RestTemplate` doesn't appear to be autoconfigured anymore and has to be explicitly defined by the application. Further a different `OAuth2RestTemplate` is used internally by the OAuth2 related Spring Security filters to convert the auth_code to the token, this can be customized using a `UserInfoRestTemplateCustomizer`, I have now used this to add the `OpenIDTokenProvider` in the chain