### PR TITLE
Fixed typo in redirect URL for client id.

### DIFF
--- a/authcode/src/main/java/org/cloudfoundry/identity/samples/authcode/Application.java
+++ b/authcode/src/main/java/org/cloudfoundry/identity/samples/authcode/Application.java
@@ -111,7 +111,7 @@ public class Application {
         }
         URL url = new URL(request.getRequestURL().toString());
         String urlStr = url.getProtocol() + "://" + url.getAuthority();
-        return "redirect:" + ssoServiceUrl + "/logout.do?redirect=" + urlStr + "&clientId=" + clientId;
+        return "redirect:" + ssoServiceUrl + "/logout.do?redirect=" + urlStr + "&client_id=" + clientId;
     }
 
     private Map<String, ?> parseToken(String base64Token) throws IOException {


### PR DESCRIPTION
Changed to use the right value for client ID for single logout redirect.