### PR TITLE
URL Cleanup

### DIFF
--- a/authcode/src/main/resources/log4j.xml
+++ b/authcode/src/main/resources/log4j.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<log4j:configuration xmlns:log4j="https://jakarta.apache.org/log4j/">
 
     <!-- Appenders -->
     <appender name="console" class="org.apache.log4j.ConsoleAppender">

--- a/client_credentials/src/main/resources/log4j.xml
+++ b/client_credentials/src/main/resources/log4j.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<log4j:configuration xmlns:log4j="https://jakarta.apache.org/log4j/">
 
     <!-- Appenders -->
     <appender name="console" class="org.apache.log4j.ConsoleAppender">

--- a/implicit/src/main/resources/log4j.xml
+++ b/implicit/src/main/resources/log4j.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<log4j:configuration xmlns:log4j="https://jakarta.apache.org/log4j/">
 
     <!-- Appenders -->
     <appender name="console" class="org.apache.log4j.ConsoleAppender">

--- a/password/src/main/resources/log4j.xml
+++ b/password/src/main/resources/log4j.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<log4j:configuration xmlns:log4j="https://jakarta.apache.org/log4j/">
 
     <!-- Appenders -->
     <appender name="console" class="org.apache.log4j.ConsoleAppender">

--- a/resource-server/src/main/resources/log4j.xml
+++ b/resource-server/src/main/resources/log4j.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<log4j:configuration xmlns:log4j="https://jakarta.apache.org/log4j/">
 
     <!-- Appenders -->
     <appender name="console" class="org.apache.log4j.ConsoleAppender">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://jakarta.apache.org/log4j/ with 5 occurrences migrated to:  
  https://jakarta.apache.org/log4j/ ([https](https://jakarta.apache.org/log4j/) result 301).