### PR TITLE
URL Cleanup

### DIFF
--- a/authcode/build.gradle
+++ b/authcode/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        mavenCentral()
+        maven { url 'https://repo.maven.apache.org/maven2/' }
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.5.RELEASE")
@@ -13,7 +13,7 @@ apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 
 repositories {
-    mavenCentral()
+    maven { url 'https://repo.maven.apache.org/maven2/' }
 }
 
 dependencies {

--- a/client_credentials/build.gradle
+++ b/client_credentials/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        mavenCentral()
+        maven { url 'https://repo.maven.apache.org/maven2/' }
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.5.RELEASE")
@@ -13,7 +13,7 @@ apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 
 repositories {
-    mavenCentral()
+    maven { url 'https://repo.maven.apache.org/maven2/' }
 }
 
 dependencies {

--- a/implicit/build.gradle
+++ b/implicit/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        mavenCentral()
+        maven { url 'https://repo.maven.apache.org/maven2/' }
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.5.RELEASE")
@@ -13,7 +13,7 @@ apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 
 repositories {
-    mavenCentral()
+    maven { url 'https://repo.maven.apache.org/maven2/' }
 }
 
 dependencies {

--- a/password/build.gradle
+++ b/password/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        mavenCentral()
+        maven { url 'https://repo.maven.apache.org/maven2/' }
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.5.RELEASE")
@@ -13,7 +13,7 @@ apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 
 repositories {
-    mavenCentral()
+    maven { url 'https://repo.maven.apache.org/maven2/' }
 }
 
 dependencies {

--- a/resource-server/build.gradle
+++ b/resource-server/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        mavenCentral()
+        maven { url 'https://repo.maven.apache.org/maven2/' }
     }
     dependencies {
         classpath('org.springframework.boot:spring-boot-gradle-plugin:1.5.5.RELEASE')
@@ -13,7 +13,7 @@ apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 
 repositories {
-    mavenCentral()
+    maven { url 'https://repo.maven.apache.org/maven2/' }
 }
 
 dependencies {


### PR DESCRIPTION
- This project uses an old version of Gradle in which mavenCentral() and
  jcenter() use http instead of https. This commit switches to use an
  explicit URL so https is used.